### PR TITLE
Add board definition for ESP32-S3-ZERO module

### DIFF
--- a/boards/ESP32_4MB.csv
+++ b/boards/ESP32_4MB.csv
@@ -1,0 +1,6 @@
+# Name,     Type, SubType, Offset,   Size, Flags
+nvs,        data, nvs,     0x9000,   0x5000
+otadata,    data, ota,     0xe000,   0x2000
+app0,       app,  ota_0,   0x010000, 0x300000
+spiffs,     data, spiffs,  0x310000, 0x0D0000
+coredump,   data, coredump,,64K

--- a/boards/esp32-s3-zero-n4r2.json
+++ b/boards/esp32-s3-zero-n4r2.json
@@ -1,0 +1,50 @@
+{
+  "build": {
+    "psram": true,
+    "arduino": {
+      "ldscript": "esp32s3_out.ld",
+      "memory_type": "qio_qspi"
+    },
+    "core": "esp32",
+    "extra_flags": [
+      "-DARDUINO_ESP32S3_DEV",
+      "-DBOARD_HAS_PSRAM"
+    ],
+    "f_cpu": "240000000L",
+    "f_flash": "80000000L",
+    "flash_mode": "qio",
+    "psram_type": "qspi",
+    "hwids": [
+      ["0x303A", "0x1001"]
+    ],
+    "mcu": "esp32s3",
+    "variant": "esp32s3"
+  },
+  
+  "arduino": {
+    "partitions": "boards/ESP32_4MB.csv"
+  },
+
+  "connectivity": ["wifi", "bluetooth"],
+
+  "debug": {
+    "default_tool": "esp-builtin",
+    "onboard_tools": ["esp-builtin"],
+    "openocd_target": "esp32s3.cfg"
+  },
+
+  "frameworks": ["arduino", "espidf"],
+
+  "name": "Waveshare ESP32-S3 Zero N4R2 (4 MB Flash / 2 MB PSRAM)",
+
+  "upload": {
+    "flash_size": "4MB",
+    "maximum_ram_size": 327680,
+    "maximum_size": 4194304,
+    "require_upload_port": true,
+    "speed": 921600
+  },
+
+  "url": "https://www.waveshare.com/wiki/ESP32-S3-Zero",
+  "vendor": "Waveshare"
+}

--- a/variants/esp32-s3-zero-n4r2.ini
+++ b/variants/esp32-s3-zero-n4r2.ini
@@ -1,0 +1,24 @@
+[env:esp32-s3-zero-n4r2]
+board = esp32-s3-zero-n4r2
+board_build.psram = enabled
+board_build.partitions = boards/ESP32_4MB.csv
+
+; Drop into bootloader automatically
+board_upload.before_reset = usb_reset 
+;board_upload.erase_flash = true
+
+build_flags =
+    ${env.build_flags}
+    ${moonlight.build_flags}
+    ${livescripts.build_flags}
+    -DARDUINO_USB_MODE=1                  ; Use on-chip CDC/JTAG engine
+    -DARDUINO_USB_CDC_ON_BOOT=1           ; CDC up immediately at boot
+    -D CONFIG_IDF_TARGET_ESP32S3=1
+    -D LOLIN_WIFI_FIX
+    ${HP_PHYSICAL_DRIVER_S3.build_flags}
+
+lib_deps =
+    ${env.lib_deps}
+    ${moonlight.lib_deps}
+    ${livescripts.lib_deps}
+    ${HP_PHYSICAL_DRIVER_S3.lib_deps}


### PR DESCRIPTION
Please review against the board documentation: https://www.waveshare.com/wiki/ESP32-S3-Zero. OTA is disabled to make it fit on 4MB.