### PR TITLE
Ethernet supporting ethernet types 

### DIFF
--- a/docs/develop/standardsguidelines.md
+++ b/docs/develop/standardsguidelines.md
@@ -44,7 +44,7 @@ The 🐰 (see AI) will review each commit, please process the review recommendat
 
 Before merging a PR back into main ask the 🐰 the following:
 
-@coderabbitai, I am about to merge this PR, please do an in-depth review of all the commits made, make a summary,  a recommendation to merge and a list of possible future actions.
+@coderabbitai, I am about to merge this PR, please do an in-depth review of all the commits made in this PR, make a summary,  a recommendation to merge and a list of possible future actions.
 
 ## Artificial Intelligence
 

--- a/docs/moonbase/inputoutput.md
+++ b/docs/moonbase/inputoutput.md
@@ -273,6 +273,21 @@ The **I2C frequency** can be adjusted (default 100 kHz). Higher frequencies (400
 * After install, select the QuinLED board preset to have the pins assigned correctly.
 * Features onboard LAN8720A ethernet — automatically configured by the board preset (ethernetType = LAN8720, RMII pins assigned)
 
+!!! warning "GPIO 1 and GPIO 3 — UART0 TX/RX"
+    The Dig-Octa routes **GPIO 1** (UART0 TX) and **GPIO 3** (UART0 RX) to two of its eight LED outputs. These pins are shared with the USB-serial interface used for flashing and serial monitoring.
+
+    When used as LED pins, MoonLight automatically suppresses UART0 output (both `Serial` and ESP-IDF logging) to prevent the LED driver and UART driver from fighting over the pin, which would cause serial noise and eventual watchdog crashes.
+
+    However, the USB-serial chip is **hardwired** to GPIO 1/3 — so the serial monitor will still show garbage characters (`>>>?>>>...`) as it interprets the LED data signal as serial data. This is electrical, not a software bug — there is no way to prevent it.
+
+    **Consequences of using GPIO 1/3 as LED pins:**
+
+    - All serial debug output is lost (logging is suppressed)
+    - Serial monitor shows garbage from LED data on the TX pin
+    - You lose the ability to diagnose issues via serial
+
+    The board preset marks GPIO 1 and 3 as **Reserved** by default. If you need all 8 outputs, you can manually reassign them to LED — but be aware of the trade-offs above.
+
 !!! tip "Reset router"
     You might need to reset your router if you first run WLED on the same board and no new IP is assigned.
 

--- a/lib/framework/EthernetSettingsService.cpp
+++ b/lib/framework/EthernetSettingsService.cpp
@@ -110,6 +110,7 @@ void EthernetSettingsService::configureNetwork(ethernet_settings_t &network)
     }
 #endif
     else {
+        // Fallback for boards with built-in ethernet that works with default ETH.begin()
         ETH.begin();
     }
     // set hostname (again) after (re)starting ethernet due to a bug in the ESP-IDF implementation

--- a/lib/framework/EthernetSettingsService.cpp
+++ b/lib/framework/EthernetSettingsService.cpp
@@ -33,6 +33,19 @@ EthernetSettingsService::EthernetSettingsService(PsychicHttpServer *server,
 
 void EthernetSettingsService::initEthernet()
 {
+    // 🌙 Disable WiFi BEFORE starting ethernet to free ~50KB heap.
+    // EMAC DMA buffers are allocated during ETH.begin() — if WiFi is still running,
+    // there may not be enough heap for both, causing "no mem for receive buffer" errors.
+    // Use WiFi.mode(WIFI_OFF) only — it handles disconnect + stop + deinit in one call.
+    // Do NOT call WiFi.disconnect(true) separately as double-deinit causes
+    // "wifi_init_default: netstack cb reg failed" errors and leaks memory.
+    if (WiFi.getMode() != WIFI_OFF) {
+        ESP_LOGI(SVK_TAG, "Disabling WiFi before ethernet init to free heap (free: %lu)", (unsigned long)ESP.getFreeHeap());
+        WiFi.mode(WIFI_OFF);
+        _wifiDisabledByEthernet = true;
+        ESP_LOGI(SVK_TAG, "WiFi disabled (free heap now: %lu)", (unsigned long)ESP.getFreeHeap());
+    }
+
     // make sure the interface is stopped before continuing and initializing
     ETH.end();
     _fsPersistence.readFromFS();
@@ -110,8 +123,24 @@ void EthernetSettingsService::reconfigureEthernet()
 
 void EthernetSettingsService::updateEthernet()
 {
+    bool ethConnected = ETH.connected();
+
+    // 🌙 Disable WiFi when ethernet is connected to free ~50KB heap (critical on ESP32-D0).
+    // Re-enable WiFi when ethernet is lost so the device remains reachable.
+    if (ethConnected && !_wifiDisabledByEthernet) {
+        ESP_LOGI(SVK_TAG, "Ethernet connected — disabling WiFi to free heap (free: %lu)", (unsigned long)ESP.getFreeHeap());
+        WiFi.mode(WIFI_OFF);
+        _wifiDisabledByEthernet = true;
+        ESP_LOGI(SVK_TAG, "WiFi disabled (free heap now: %lu)", (unsigned long)ESP.getFreeHeap());
+    } else if (!ethConnected && _wifiDisabledByEthernet) {
+        ESP_LOGI(SVK_TAG, "Ethernet lost — re-enabling WiFi");
+        WiFi.mode(WIFI_STA);
+        WiFi.begin();
+        _wifiDisabledByEthernet = false;
+    }
+
     JsonDocument doc;
-    doc["connected"] = ETH.connected();
+    doc["connected"] = ethConnected;
     JsonObject jsonObject = doc.as<JsonObject>();
     _socket->emitEvent(EVENT_ETHERNET, jsonObject);
 }

--- a/lib/framework/EthernetSettingsService.cpp
+++ b/lib/framework/EthernetSettingsService.cpp
@@ -127,15 +127,19 @@ void EthernetSettingsService::updateEthernet()
 
     // 🌙 Disable WiFi when ethernet is connected to free ~50KB heap (critical on ESP32-D0).
     // Re-enable WiFi when ethernet is lost so the device remains reachable.
-    if (ethConnected && !_wifiDisabledByEthernet && WiFi.getMode() != WIFI_OFF) {
+    if (ethConnected && WiFi.getMode() != WIFI_OFF) {
+        // 🌙 Always re-disable WiFi while ethernet is connected — WiFiSettingsService
+        // may have re-enabled it via manageSTA()/scanNetworks().
         ESP_LOGI(SVK_TAG, "Ethernet connected — disabling WiFi to free heap (free: %lu)", (unsigned long)ESP.getFreeHeap());
         WiFi.mode(WIFI_OFF);
         _wifiDisabledByEthernet = true;
         ESP_LOGI(SVK_TAG, "WiFi disabled (free heap now: %lu)", (unsigned long)ESP.getFreeHeap());
     } else if (!ethConnected && _wifiDisabledByEthernet) {
-        ESP_LOGI(SVK_TAG, "Ethernet lost — re-enabling WiFi");
-        WiFi.mode(WIFI_STA);
-        WiFi.begin();
+        // 🌙 Just clear the flag — WiFiSettingsService::manageSTA() will handle
+        // reconnection with proper credentials on its next loop iteration.
+        // Don't call WiFi.begin() here: WiFi.persistent(false) means credentials
+        // aren't stored, so WiFi.begin() without SSID/password would fail.
+        ESP_LOGI(SVK_TAG, "Ethernet lost — allowing WiFi reconnection");
         _wifiDisabledByEthernet = false;
     }
 

--- a/lib/framework/EthernetSettingsService.cpp
+++ b/lib/framework/EthernetSettingsService.cpp
@@ -127,7 +127,7 @@ void EthernetSettingsService::updateEthernet()
 
     // 🌙 Disable WiFi when ethernet is connected to free ~50KB heap (critical on ESP32-D0).
     // Re-enable WiFi when ethernet is lost so the device remains reachable.
-    if (ethConnected && !_wifiDisabledByEthernet) {
+    if (ethConnected && !_wifiDisabledByEthernet && WiFi.getMode() != WIFI_OFF) {
         ESP_LOGI(SVK_TAG, "Ethernet connected — disabling WiFi to free heap (free: %lu)", (unsigned long)ESP.getFreeHeap());
         WiFi.mode(WIFI_OFF);
         _wifiDisabledByEthernet = true;

--- a/lib/framework/EthernetSettingsService.h
+++ b/lib/framework/EthernetSettingsService.h
@@ -146,6 +146,7 @@ private:
     FSPersistence<EthernetSettings> _fsPersistence;
     EventSocket *_socket;
     unsigned long _lastEthernetUpdate;
+    bool _wifiDisabledByEthernet = false; // 🌙 tracks whether we disabled WiFi for ethernet
 
     void configureNetwork(ethernet_settings_t &network);
     void reconfigureEthernet();

--- a/lib/framework/WiFiSettingsService.cpp
+++ b/lib/framework/WiFiSettingsService.cpp
@@ -323,7 +323,6 @@ void WiFiSettingsService::manageSTA()
         return;
     }
 #endif
-    else
     {
 #ifdef SERIAL_INFO
         Serial.println("Connecting to WiFi...");

--- a/lib/framework/WiFiSettingsService.cpp
+++ b/lib/framework/WiFiSettingsService.cpp
@@ -15,6 +15,9 @@
 #include <WiFiSettingsService.h>
 
 #include <ESP32SvelteKit.h> // 🌙 safeMode
+#if FT_ENABLED(FT_ETHERNET)
+#include <ETH.h> // 🌙 ETH.connected() check in manageSTA()
+#endif
 
 WiFiSettingsService::WiFiSettingsService(PsychicHttpServer *server,
                                          FS *fs,
@@ -313,6 +316,13 @@ void WiFiSettingsService::manageSTA()
     {
         return;
     }
+    // 🌙 Don't reconnect WiFi while ethernet is active — saves ~50KB heap on ESP32-D0
+#if FT_ENABLED(FT_ETHERNET)
+    if (ETH.connected())
+    {
+        return;
+    }
+#endif
     else
     {
 #ifdef SERIAL_INFO

--- a/platformio.ini
+++ b/platformio.ini
@@ -57,7 +57,7 @@ build_flags =
     -D BUILD_TARGET=\"$PIOENV\"
     -D APP_NAME=\"MoonLight\" ; 🌙 Must only contain characters from [a-zA-Z0-9-_] as this is converted into a filename
     -D APP_VERSION=\"0.9.1\" ; semver compatible version string
-    -D APP_DATE=\"20260315\" ; 🌙
+    -D APP_DATE=\"20260316\" ; 🌙
 
     -D PLATFORM_VERSION=\"pioarduino-55.03.37\" ; 🌙 make sure it matches with above plaftform
 

--- a/src/MoonBase/Modules/ModuleIO.h
+++ b/src/MoonBase/Modules/ModuleIO.h
@@ -793,6 +793,7 @@ class ModuleIO : public Module {
     // 🌙 Ethernet configuration — reads ethernetType + pin assignments from board preset
     EthernetSettingsService* ess = _sveltekit->getEthernetSettingsService();
     ess->v_ETH_SPI_CONFIGURED = false;
+    ess->v_ETH_PHY_ADDR = 0;
     ess->v_ETH_SPI_SCK = -1;
     ess->v_ETH_SPI_MISO = -1;
     ess->v_ETH_SPI_MOSI = -1;

--- a/src/MoonBase/Modules/ModuleIO.h
+++ b/src/MoonBase/Modules/ModuleIO.h
@@ -657,22 +657,11 @@ class ModuleIO : public Module {
       pinAssigner.assignPin(16, pin_LED);
   #endif
 
-  #ifdef CONFIG_IDF_TARGET_ESP32
-      pinAssigner.assignPin(21, pin_I2C_SDA);
-      pinAssigner.assignPin(22, pin_I2C_SCL);
-  #elif defined(CONFIG_IDF_TARGET_ESP32S2) || defined(CONFIG_IDF_TARGET_ESP32S3) || defined(CONFIG_IDF_TARGET_ESP32C3)
-      pinAssigner.assignPin(8, pin_I2C_SDA);
-      pinAssigner.assignPin(9, pin_I2C_SCL);
-  #elif defined(CONFIG_IDF_TARGET_ESP32C6)
-      pinAssigner.assignPin(23, pin_I2C_SDA);
-      pinAssigner.assignPin(22, pin_I2C_SCL);
-  #elif defined(CONFIG_IDF_TARGET_ESP32P4)
-      pinAssigner.assignPin(7, pin_I2C_SDA);
-      pinAssigner.assignPin(8, pin_I2C_SCL);
-  #else
-      pinAssigner.assignPin(21, pin_I2C_SDA);  // Fallback
-      pinAssigner.assignPin(22, pin_I2C_SCL);
-  #endif
+      // Use board-variant defaults from pins_arduino.h — no #ifdef chain needed
+      pinAssigner.assignPin(SDA, pin_I2C_SDA);
+      pinAssigner.assignPin(SCL, pin_I2C_SCL);
+      pinAssigner.assignPin(TX,  pin_Serial_TX);
+      pinAssigner.assignPin(RX,  pin_Serial_RX);
 
       // trying to add more pins, but these pins not liked by esp32-d0-16mb ... 🚧
       // pinAssigner.assignPin(4, pin_LED_02;

--- a/src/MoonBase/SharedWebSocketServer.h
+++ b/src/MoonBase/SharedWebSocketServer.h
@@ -108,10 +108,14 @@ class SharedWebSocketServer {
     String buffer;
     serializeJson(doc, buffer);
 
+    // Guard against NULL from String::c_str() when heap is too low for serialization
+    const char* data = buffer.c_str();
+    if (!data || buffer.length() == 0) return;
+
     if (client) {
-      client->sendMessage(buffer.c_str());
+      client->sendMessage(data);
     } else {
-      _handler.sendAll(buffer.c_str());
+      _handler.sendAll(data);
     }
   }
 

--- a/src/MoonBase/SharedWebSocketServer.h
+++ b/src/MoonBase/SharedWebSocketServer.h
@@ -108,9 +108,8 @@ class SharedWebSocketServer {
     String buffer;
     serializeJson(doc, buffer);
 
-    // Guard against NULL from String::c_str() when heap is too low for serialization
+    if (buffer.length() == 0) return;
     const char* data = buffer.c_str();
-    if (!data || buffer.length() == 0) return;
 
     if (client) {
       client->sendMessage(data);

--- a/src/MoonLight/Modules/ModuleDrivers.h
+++ b/src/MoonLight/Modules/ModuleDrivers.h
@@ -81,7 +81,7 @@ class ModuleDrivers : public NodeManager {
               Serial.end();
               _uartSuppressed = true;
             } else if (!needsUartSuppression && _uartSuppressed) {
-              Serial.begin(115200);
+              Serial.begin(SERIAL_BAUD_RATE);
               esp_log_set_vprintf(_origVprintf);
               _uartSuppressed = false;
               EXT_LOGI(ML_TAG, "UART0 TX/RX (GPIO %d/%d) no longer LED pins — UART0 and logging restored", TX, RX);

--- a/src/MoonLight/Modules/ModuleDrivers.h
+++ b/src/MoonLight/Modules/ModuleDrivers.h
@@ -64,6 +64,19 @@ class ModuleDrivers : public NodeManager {
             }
           }
 
+          // GPIO 1 (UART0 TX) / GPIO 3 (UART0 RX) as LED pin: disable all UART0 output
+          // to prevent the I2S LED driver and UART driver from fighting over the pin,
+          // which causes serial noise and eventual watchdog crash.
+          // Note: using GPIO 1/3 as LED pins is discouraged — you lose all serial debugging.
+          for (int i = 0; i < layerP.nrOfLedPins; i++) {
+            if (layerP.ledPins[i] == 1 || layerP.ledPins[i] == 3) {
+              EXT_LOGW(ML_TAG, "GPIO %d used as LED pin — disabling UART0 to prevent crash (serial debug lost!)", layerP.ledPins[i]);
+              Serial.end();
+              esp_log_set_vprintf([](const char*, va_list) -> int { return 0; });  // suppress ESP_LOGx
+              break;
+            }
+          }
+
           // log pins
           for (int i = 0; i < layerP.nrOfLedPins; i++) {
             if (layerP.ledsPerPin[i] > 0 && layerP.ledsPerPin[i] != UINT16_MAX) EXT_LOGD(ML_TAG, "ledPins[%d-%d] = %d (#%d)", i, layerP.nrOfLedPins, layerP.ledPins[i], layerP.ledsPerPin[i]);

--- a/src/MoonLight/Modules/ModuleDrivers.h
+++ b/src/MoonLight/Modules/ModuleDrivers.h
@@ -22,8 +22,6 @@
 
 class ModuleDrivers : public NodeManager {
  public:
-  ModuleLightsControl* _moduleLightsControl;
-  ModuleIO* _moduleIO;
   ModuleDrivers(PsychicHttpServer* server, ESP32SvelteKit* sveltekit, FileManager* fileManager, ModuleLightsControl* moduleLightsControl, ModuleIO* moduleIO) : NodeManager("drivers", server, sveltekit, fileManager) {
     _moduleLightsControl = moduleLightsControl;
     _moduleIO = moduleIO;
@@ -64,16 +62,29 @@ class ModuleDrivers : public NodeManager {
             }
           }
 
-          // GPIO 1 (UART0 TX) / GPIO 3 (UART0 RX) as LED pin: disable all UART0 output
+          // UART0 TX/RX pins used as LED pin: disable all UART0 output
           // to prevent the I2S LED driver and UART driver from fighting over the pin,
           // which causes serial noise and eventual watchdog crash.
-          // Note: using GPIO 1/3 as LED pins is discouraged — you lose all serial debugging.
-          for (int i = 0; i < layerP.nrOfLedPins; i++) {
-            if (layerP.ledPins[i] == 1 || layerP.ledPins[i] == 3) {
-              EXT_LOGW(ML_TAG, "GPIO %d used as LED pin — disabling UART0 to prevent crash (serial debug lost!)", layerP.ledPins[i]);
+          // TX/RX are board-specific (ESP32: 1/3, S3: 43/44, C3: 21/20, P4: 37/38).
+          // Note: using UART0 pins as LED pins is discouraged — you lose all serial debugging.
+          {
+            bool needsUartSuppression = false;
+            for (int i = 0; i < layerP.nrOfLedPins; i++) {
+              if (layerP.ledPins[i] == TX || layerP.ledPins[i] == RX) {
+                needsUartSuppression = true;
+                break;
+              }
+            }
+            if (needsUartSuppression && !_uartSuppressed) {
+              EXT_LOGW(ML_TAG, "UART0 TX/RX (GPIO %d/%d) used as LED pin — disabling UART0 to prevent crash (serial debug lost!)", TX, RX);
+              _origVprintf = esp_log_set_vprintf([](const char*, va_list) -> int { return 0; });
               Serial.end();
-              esp_log_set_vprintf([](const char*, va_list) -> int { return 0; });  // suppress ESP_LOGx
-              break;
+              _uartSuppressed = true;
+            } else if (!needsUartSuppression && _uartSuppressed) {
+              Serial.begin(115200);
+              esp_log_set_vprintf(_origVprintf);
+              _uartSuppressed = false;
+              EXT_LOGI(ML_TAG, "UART0 TX/RX (GPIO %d/%d) no longer LED pins — UART0 and logging restored", TX, RX);
             }
           }
 
@@ -130,7 +141,7 @@ class ModuleDrivers : public NodeManager {
         },
         _moduleName);
 
-    #if FT_LIVESCRIPT
+  #if FT_LIVESCRIPT
     // find layout/driver live scripts (.sc files with L_ or D_ prefix) on FS
     File rootFolder = ESPFS.open("/");
     walkThroughFiles(rootFolder, [&](File folder, File file) {
@@ -145,7 +156,7 @@ class ModuleDrivers : public NodeManager {
       }
     });
     rootFolder.close();
-    #endif
+  #endif
   }
 
   Node* addNode(const uint8_t index, char* name, const JsonArray& controls) const override {
@@ -219,6 +230,12 @@ class ModuleDrivers : public NodeManager {
 
     return node;
   }
+
+ private:
+  ModuleLightsControl* _moduleLightsControl;
+  ModuleIO* _moduleIO;
+  bool _uartSuppressed = false;
+  vprintf_like_t _origVprintf = nullptr;
 
 };  // class ModuleDrivers
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved WiFi↔Ethernet auto-switching to avoid conflicts and reduce heap usage; WiFi is now disabled while Ethernet is active and restored when Ethernet is lost
  * Ensured Ethernet reliably starts with a defensive fallback path
  * Skips sending empty WebSocket messages and avoids redundant string handling

* **Refactor**
  * Tightened internal member visibility and simplified board pin assignment

* **Documentation**
  * Added prominent warning about using UART0 pins (GPIO1/3) as LED outputs
<!-- end of auto-generated comment: release notes by coderabbit.ai -->