### PR TITLE
fix: harden Dig-Next-2 wearable runtime

### DIFF
--- a/docs/plans/2026-08-16-1954-feat-native-white-vest-firmware-plan.md
+++ b/docs/plans/2026-08-16-1954-feat-native-white-vest-firmware-plan.md
@@ -1,0 +1,49 @@
+# Native White Vest Firmware Plan
+
+## Goal
+
+Ship one identifiable Dig-Next-2 firmware build that contains the ordered 95-pixel vest geometry natively and fixes the reconnect loop without altering stored Wi-Fi or activating LED output during the flash.
+
+## Settled decisions
+
+- Target only PlatformIO environment `esp32-d0-pico2` for QuinLED Dig-Next-2 v1r3b.
+- Compile the vest geometry into C++; do not use Live Script.
+- Register `White Vest 95` as a selectable 3D layout, but do not change the empty default or persisted node selection.
+- Clear the Wi-Fi connection attempt only on `ARDUINO_EVENT_WIFI_STA_GOT_IP`, not association.
+- Identify this build as `1.0.0-whitevest.2` dated `20260816`; publish tag `v1.0.0-whitevest.2`.
+- Read the OTA selection first, then flash only the selected app partition (`app0` at `0x10000` or `app1` at `0x340000`) without erase, preserving filesystem and NVS settings.
+
+## Requirements
+
+- R1: Native layout contains exactly the 95 `L_Vest.sc` coordinates in physical/index order and one `nextPin()` boundary.
+- R2: Firmware builds for `esp32-d0-pico2` and leaves the vest layout inert until explicitly selected.
+- R3: DHCP must complete before the reconnect timer considers a station connection successful.
+- R4: `/rest/systemStatus` and artifact naming must distinguish the custom build.
+- R5: Identify and capture the complete active app partition with a checksum; flash and rollback must use that app slot without erase.
+- R6: Publish reviewed, secret-free source and tag the exact custom version.
+
+## Work units
+
+### U1 — Native vest layout
+
+Add `src/MoonLight/Nodes/Layouts/L_WhiteVest95.h`, include it from `src/MoonBase/Nodes.h`, and register it in both layout enumeration and allocation paths in `src/MoonLight/Modules/ModuleDrivers.h`. Keep the raw atlas tuples visibly comparable with the canonical map, but scale them to a collision-free `6×6×20` virtual space before calling `addLight`; the raw `0..255` extent allocates about 16.45 million dense cells and trips the task watchdog. Resolve the persisted `/L_WhiteVest95.sc` name to this native layout before the generic Live Script fallback.
+
+Evidence: an automated comparison against `vest/firmware/moonlight/L_Vest.sc` in the handoff repo proves all 95 coordinates in exact order, 95 unique scaled coordinates, 14 unique around-body columns, a 720-cell dense extent, and one pin boundary; the target build succeeds. The unrelated 14×8 Live Script geometry is explicitly excluded.
+
+### U2 — Connectivity and identity
+
+Change the existing station event handler in `lib/framework/WiFiSettingsService.cpp` from `STA_CONNECTED` to `STA_GOT_IP`, update its comment, and set `APP_VERSION`/`APP_DATE` in `platformio.ini`.
+
+Evidence: focused diff review and successful target compilation; post-flash serial output shows association followed by DHCP without the prior repeated reconnect.
+
+### U3 — Flash, verify, publish
+
+Read OTA selection and checksum the complete active rollback partition and custom app binary. With the user-confirmed absence of 12 V input and LED terminal wiring as the output-off safety condition, perform an app-only serial flash to the selected app slot. Then verify boot, network reachability, custom system status, and native layout registration without changing the persisted driver selection. Selecting the 95-light layout and validating physical pixels is a separate post-wiring gate. Stop on panic/reset loop or lost connectivity. Push a reviewed branch, merge it into the public fork, tag the release, build the tag, and ensure the installed bytes/version match the published build.
+
+## Definition of done
+
+- Narrow coordinate check and `pio run -e esp32-d0-pico2` exit zero without masked failures.
+- Focused diff and secret scan are clean; an independent review has no blocking findings.
+- Active slot and prior/custom app images have recorded SHA-256 checksums.
+- Device boots the custom version, allocates 720 virtual cells/2,880 bytes for exactly 95 LEDs, obtains HouseNet IoT DHCP, remains reachable, reports the expected target/version, and keeps output off. Authentication failure of the preserved Wi-Fi profile is a separate unresolved configuration gate, not firmware stability proof.
+- Source is merged to `novotnyllc/MoonLight`, tag `v1.0.0-whitevest.2` is published, and the final flashed image is the tagged artifact.

--- a/docs/plans/2026-08-16-1954-feat-native-white-vest-firmware-plan.md
+++ b/docs/plans/2026-08-16-1954-feat-native-white-vest-firmware-plan.md
@@ -45,5 +45,5 @@ Read OTA selection and checksum the complete active rollback partition and custo
 - Narrow coordinate check and `pio run -e esp32-d0-pico2` exit zero without masked failures.
 - Focused diff and secret scan are clean; an independent review has no blocking findings.
 - Active slot and prior/custom app images have recorded SHA-256 checksums.
-- Device boots the custom version, allocates 720 virtual cells/2,880 bytes for exactly 95 LEDs, obtains HouseNet IoT DHCP, remains reachable, reports the expected target/version, and keeps output off. Authentication failure of the preserved Wi-Fi profile is a separate unresolved configuration gate, not firmware stability proof.
+- Device boots the custom version, allocates 720 virtual cells/2,880 bytes for exactly 95 LEDs, obtains HouseNet IoT DHCP, remains reachable, reports the expected target/version, and keeps output off. The stored Wi-Fi profile was verified unchanged; transient authentication retries cleared without a settings write.
 - Source is merged to `novotnyllc/MoonLight`, tag `v1.0.0-whitevest.2` is published, and the final flashed image is the tagged artifact.

--- a/docs/plans/2026-08-16-2130-fix-vest-runtime-hardening-plan.md
+++ b/docs/plans/2026-08-16-2130-fix-vest-runtime-hardening-plan.md
@@ -1,0 +1,130 @@
+---
+title: Dig-Next-2 Wearables Runtime Hardening - Plan
+type: fix
+date: 2026-08-16
+artifact_contract: ce-unified-plan/v1
+artifact_readiness: implementation-ready
+product_contract_source: ce-plan-bootstrap
+execution: code
+---
+
+# Dig-Next-2 Wearables Runtime Hardening - Plan
+
+## Goal Capsule
+
+Create one reusable Dig-Next-2 MoonLight runtime for the White Vest and coat. Keep garment geometry in separate native layouts while fixing large HTTP responses, local mDNS discovery, and the built-in PDM microphone once at the controller/runtime layer. Ship the runtime only after the tagged app binary is installed and sound-reactive plus physical LED behavior are observed on the White Vest validation device.
+
+## Product Contract
+
+### Summary
+
+The shared Dig-Next-2 runtime must serve its web UI, advertise each device's configured hostname, acquire usable microphone samples, and drive garment-specific native layouts without reverting to WLED or Live Script.
+
+### Problem Frame
+
+The current `1.0.0-whitevest.2` build stays online and serves small REST responses, but responses around 2.1 KB and the root UI stall after headers. The firmware starts mDNS before DHCP completes, and the FastLED PDM input on the official Dig-Next-2 GPIO7/GPIO8 pins reports initialization failure. These failures block configuration and sound-reactive use even though the native layout is healthy.
+
+### Requirements
+
+**HTTP and discovery**
+
+- R1. Root UI, file, JSON, and chunked responses must complete across the observed size boundary without blocking the HTTP task.
+- R2. `white-vest-next.local` must resolve after DHCP and after a Wi-Fi reconnect.
+
+**Audio and effects**
+
+- R3. The built-in Dig-Next-2 PDM microphone must initialize on official GPIO7 data and GPIO8 clock assignments.
+- R4. Live audio must produce changing volume and frequency-band data and visibly drive a sound-reactive effect.
+
+**Release and physical proof**
+
+- R5. The native White Vest layout must remain 95 RGB pixels on LED1/GPIO2 with a `6×6×20` mapping and 720 virtual cells.
+- R6. Updates must remain app-only until physical validation succeeds, preserving NVS and LittleFS.
+- R7. A plain 95-pixel solid-color test must pass before mapped or sound-reactive effects are accepted.
+- R8. After all functional gates pass, capture and checksum the complete Dig-Next-2 flash for exact restoration.
+- R9. HTTP, mDNS, PDM audio, and packaging fixes must remain shared Dig-Next-2 behavior; garment layouts and hostnames must remain independent configuration.
+- R10. One firmware image must enumerate every available native garment layout and persist the selected layout independently on each controller.
+
+## Planning Contract
+
+### Key Technical Decisions
+
+- KTD1. **Characterize the response-size boundary before changing transport code.** One generated response seam must prove the failing threshold and the corrected single-buffer and chunked paths.
+- KTD2. **Tie mDNS lifecycle to acquired network addresses.** Do not treat a pre-DHCP `MDNS.begin()` call as successful discovery.
+- KTD3. **Keep the official microphone pins.** GPIO7/GPIO8 come from the QuinLED Dig-Next-2 pinout; correct the PDM driver or platform integration instead of guessing alternate wiring.
+- KTD4. **Prove audio at the data and effect layers.** “PDM active” alone is insufficient; nonzero changing samples and a visible reactive effect are required.
+- KTD5. **Preserve the proven layout and app-only recovery boundary.** No WLED, Live Script, filesystem erase, or full-flash write belongs in the fix cycle.
+- KTD6. **Use a generic Dig-Next-2 build identity.** Publish the runtime as `1.0.1-dignext2.2`; do not encode `whitevest` or `coat` in shared firmware identity.
+- KTD7. **Package layouts together.** Reuse the existing native layout registry so a vest or coat controller selects its own layout from the same firmware image.
+
+### Scope Boundaries
+
+- In scope: shared HTTP response handling, mDNS lifecycle, PDM capture, audio telemetry/effect proof, release, flash, physical solid-color test, and final restoration backup.
+- Deferred: authoring the coat's native coordinates until a canonical coat pixel map exists. The shared firmware and registry support that layout without a separate build. Unrelated MoonLight UI changes and speculative mutex fixes also remain deferred unless runtime evidence reaches them.
+
+## Implementation Units
+
+### U1. Characterize and fix HTTP response completion
+
+- **Goal:** Make large UI, JSON, and file responses complete without blocking the server.
+- **Requirements:** R1, R6, R9
+- **Dependencies:** None
+- **Files:** `lib/PsychicHttp/src/PsychicResponse.cpp`, `lib/PsychicHttp/src/PsychicJson.cpp`, `lib/PsychicHttp/src/PsychicFileResponse.cpp`, `test/test_native/test_http_response.cpp`
+- **Approach:** Instrument the existing response seam, identify where headers complete but body transmission blocks, and fix the shared owner rather than individual endpoints.
+- **Execution note:** Start with a focused characterization check around the observed 2 KB boundary.
+- **Test scenarios:** A response below the boundary completes; a response spanning multiple TCP segments completes; JSON and file responses report the exact body length; send failure terminates without a stuck request.
+- **Verification:** `/`, `/rest/drivers`, and a static JSON file return complete bodies repeatedly while uptime continues.
+
+### U2. Make mDNS follow the network lifecycle
+
+- **Goal:** Advertise the configured hostname whenever Wi-Fi has a usable address.
+- **Requirements:** R2, R9
+- **Dependencies:** None
+- **Files:** `lib/framework/ESP32SvelteKit.cpp`, `lib/framework/ESP32SvelteKit.h`, `lib/framework/WiFiStatus.cpp`, `test/test_native/test_network_lifecycle.cpp`
+- **Approach:** Initialize mDNS while internal memory is available, re-enable and announce it after `GOT_IP`, and refresh the advertisement every 60 seconds so the hostname remains cached across the routed 120-second TTL.
+- **Test scenarios:** Startup before DHCP does not claim discovery; first `GOT_IP` advertises the configured hostname; reconnect restores advertisement; repeated address events remain idempotent.
+- **Verification:** `white-vest-next.local` resolves to `192.168.20.239` from the Mac after boot and reconnect.
+
+### U3. Restore PDM audio and sound-reactive data
+
+- **Goal:** Capture usable audio from the built-in microphone and feed MoonLight effects.
+- **Requirements:** R3, R4, R9
+- **Dependencies:** None
+- **Files:** `src/MoonLight/Nodes/Drivers/D_FastLEDAudio.h`, `src/MoonBase/Modules/ModuleIO.h`, `firmware/esp32-d0.ini`, `test/test_native/test_audio_config.cpp`
+- **Approach:** Trace the pinned FastLED PDM creation path against ESP32-PICO-V3-02 and Arduino-ESP32 3.3.7. Keep GPIO7/GPIO8 and correct only the confirmed configuration or platform incompatibility.
+- **Test scenarios:** Official pins produce a valid PDM configuration; startup failure reports the underlying platform error; captured samples update volume and bands; silence stays near the noise floor; a sound event changes reactive effect input.
+- **Verification:** Serial and driver status show active PDM, live telemetry changes with sound, and a sound-reactive effect changes visibly.
+
+### U4. Build, review, publish, and install exact bytes
+
+- **Goal:** Deliver a review-settled versioned app artifact and install that exact artifact.
+- **Requirements:** R5, R6, R9, R10
+- **Dependencies:** U1, U2, U3
+- **Files:** `firmware/esp32-d0.ini`, `docs/plans/2026-08-16-2130-fix-vest-runtime-hardening-plan.md`
+- **Approach:** Build only `esp32-d0-pico2`, publish generic version `1.0.1-dignext2.2`, flash the app partition, and compare release and installed evidence by SHA-256.
+- **Test scenarios:** Clean target build; secret scan; independent review; release asset digest equals the flashed app artifact; boot preserves the native map and Wi-Fi profile.
+- **Verification:** Merged PR, exact tag, release asset checksum, esptool write verification, stable boot, and passing HTTP/mDNS/audio checks.
+
+### U5. Complete physical validation and restoration capture
+
+- **Goal:** Prove the installed string and retain an exact post-validation recovery image.
+- **Requirements:** R4, R7, R8
+- **Dependencies:** U4
+- **Files:** `docs/plans/2026-08-16-2130-fix-vest-runtime-hardening-plan.md`
+- **Approach:** Ask for one physical action at a time. Validate low-brightness solid red, green, and blue across all 95 pixels before enabling the native map and sound-reactive effect. Read and checksum the complete flash only after those gates pass.
+- **Test scenarios:** Every pixel responds in RGB order; no reset or visible corruption occurs; mapped effect orientation is plausible; sound changes the chosen reactive effect; complete flash read verifies by checksum.
+- **Verification:** User-observed physical pass, stable controller status, and a recorded full-flash checksum and restore warning.
+
+## Verification Contract
+
+- Native tests cover the response boundary, network lifecycle, and audio configuration seams when those seams are host-testable.
+- `pio run -e esp32-d0-pico2` must exit zero without masked failures.
+- Device proof must include complete HTTP bodies, mDNS lookup, live microphone telemetry, serial stability, native-map invariants, and exact flashed-byte verification.
+- Physical proof must use one action at a time and stop on zero lights, wrong voltage behavior, panic, reset loop, or connectivity loss.
+
+## Definition of Done
+
+- All R1-R8 requirements are satisfied with no abandoned experimental code in the diff.
+- The public release contains only secret-free source, the app-only firmware, and checksums.
+- The current controller resolves by hostname, serves the full UI, reports working audio, drives all 95 pixels, and runs a sound-reactive effect.
+- A complete post-validation Dig-Next-2 flash image is stored privately with its checksum and is never confused with the Dig-Uno rollback image.

--- a/firmware/esp32-d0.ini
+++ b/firmware/esp32-d0.ini
@@ -100,7 +100,7 @@ build_unflags =
   -D APP_VERSION=\"1.0.0\"
   -D APP_DATE=\"20260505\"
 build_flags = ${esp32-d0-base.build_flags}
-  -D APP_VERSION=\"1.0.0-whitevest.2\"
+  -D APP_VERSION=\"1.0.1-dignext2.2\"
   -D APP_DATE=\"20260816\"
   -DBOARD_HAS_PSRAM                            ; Added: Enable PSRAM
   ${livescripts.build_flags}

--- a/firmware/esp32-d0.ini
+++ b/firmware/esp32-d0.ini
@@ -96,7 +96,12 @@ board_build.partitions = default_8MB.csv       ; boards/ESP32_8MB.csv has not en
 board_build.arduino.memory_type = qio_qspi     ; Added: PSRAM memory type
 board_build.flash_mode = qio                   ; Added: Flash mode for PSRAM
 upload_speed = 460800                          ; upload_speed = 921600 was too fast ... if not set esphome web installer even uses slower speed 
+build_unflags =
+  -D APP_VERSION=\"1.0.0\"
+  -D APP_DATE=\"20260505\"
 build_flags = ${esp32-d0-base.build_flags}
+  -D APP_VERSION=\"1.0.0-whitevest.2\"
+  -D APP_DATE=\"20260816\"
   -DBOARD_HAS_PSRAM                            ; Added: Enable PSRAM
   ${livescripts.build_flags}
   ; -mfix-esp32-psram-cache-issue              ; Added: Fix ESP32 PSRAM cache bug (not sufficient alone — operator new override for QIO PSRAM causes crashes regardless, see main.cpp)

--- a/lib/PsychicHttp/src/PsychicFileResponse.cpp
+++ b/lib/PsychicHttp/src/PsychicFileResponse.cpp
@@ -1,6 +1,9 @@
 #include "PsychicFileResponse.h"
 #include "PsychicResponse.h"
 #include "PsychicRequest.h"
+#include <esp_heap_caps.h>
+
+static constexpr size_t FILE_INTERNAL_CHUNK_SIZE = 512;
 
 
 PsychicFileResponse::PsychicFileResponse(PsychicRequest *request, FS &fs, const String& path, const String& contentType, bool download)
@@ -101,9 +104,9 @@ esp_err_t PsychicFileResponse::send()
 
   //just send small files directly
   size_t size = getContentLength();
-  if (size < FILE_CHUNK_SIZE)
+  if (size < FILE_INTERNAL_CHUNK_SIZE)
   {
-    uint8_t *buffer = (uint8_t *)malloc(size);
+    uint8_t *buffer = static_cast<uint8_t *>(heap_caps_malloc(size, MALLOC_CAP_INTERNAL | MALLOC_CAP_8BIT));
     if (buffer == NULL)
     {
       /* Respond with 500 Internal Server Error */
@@ -116,12 +119,12 @@ esp_err_t PsychicFileResponse::send()
     this->setContent(buffer, readSize);
     err = PsychicResponse::send();
     
-    free(buffer);
+    heap_caps_free(buffer);
   }
   else
   {
     /* Retrieve the pointer to scratch buffer for temporary storage */
-    char *chunk = (char *)malloc(FILE_CHUNK_SIZE);
+    char *chunk = static_cast<char *>(heap_caps_malloc(FILE_INTERNAL_CHUNK_SIZE, MALLOC_CAP_INTERNAL | MALLOC_CAP_8BIT));
     if (chunk == NULL)
     {
       /* Respond with 500 Internal Server Error */
@@ -134,7 +137,7 @@ esp_err_t PsychicFileResponse::send()
     size_t chunksize;
     do {
         /* Read file in chunks into the scratch buffer */
-        chunksize = _content.readBytes(chunk, FILE_CHUNK_SIZE);
+        chunksize = _content.readBytes(chunk, FILE_INTERNAL_CHUNK_SIZE);
         if (chunksize > 0)
         {
           err = this->sendChunk((uint8_t *)chunk, chunksize);
@@ -146,7 +149,7 @@ esp_err_t PsychicFileResponse::send()
     } while (chunksize != 0);
 
     //keep track of our memory
-    free(chunk);
+    heap_caps_free(chunk);
 
     if (err == ESP_OK)
     {

--- a/lib/PsychicHttp/src/PsychicHttpServer.cpp
+++ b/lib/PsychicHttp/src/PsychicHttpServer.cpp
@@ -6,6 +6,9 @@
 #include "PsychicWebSocket.h"
 #include "PsychicJson.h"
 #include "WiFi.h"
+#include <errno.h>
+#include <netinet/tcp.h>
+#include <sys/socket.h>
 
 PsychicHttpServer::PsychicHttpServer() :
   _onOpen(NULL),
@@ -224,6 +227,13 @@ void PsychicHttpServer::onOpen(PsychicClientCallback handler) {
 esp_err_t PsychicHttpServer::openCallback(httpd_handle_t hd, int sockfd)
 {
   ESP_LOGD(PH_TAG, "New client connected %d", sockfd);
+
+  // ESP-IDF emits response headers and bodies through multiple send() calls.
+  // Disable Nagle so the final partial TCP segment is not stranded on a
+  // persistent HTTP/1.1 connection while waiting for more application data.
+  int noDelay = 1;
+  if (setsockopt(sockfd, IPPROTO_TCP, TCP_NODELAY, &noDelay, sizeof(noDelay)) < 0)
+    ESP_LOGW(PH_TAG, "Unable to enable TCP_NODELAY on client %d (%d)", sockfd, errno);
 
   //get our global server reference
   PsychicHttpServer *server = (PsychicHttpServer*)httpd_get_global_user_ctx(hd);

--- a/lib/PsychicHttp/src/PsychicJson.cpp
+++ b/lib/PsychicHttp/src/PsychicJson.cpp
@@ -1,4 +1,7 @@
 #include "PsychicJson.h"
+#include <esp_heap_caps.h>
+
+static constexpr size_t JSON_INTERNAL_CHUNK_SIZE = 512;
 
 #ifdef ARDUINOJSON_6_COMPATIBILITY
   PsychicJsonResponse::PsychicJsonResponse(PsychicRequest *request, bool isArray, size_t maxJsonBufferSize) :
@@ -37,19 +40,19 @@ esp_err_t PsychicJsonResponse::send()
   char *buffer;
 
   //how big of a buffer do we want?
-  if (length < JSON_BUFFER_SIZE)
+  if (length < JSON_INTERNAL_CHUNK_SIZE)
     buffer_size = length+1;
   else
-    buffer_size = JSON_BUFFER_SIZE;
+    buffer_size = JSON_INTERNAL_CHUNK_SIZE;
 
-  buffer = (char *)malloc(buffer_size);
+  buffer = static_cast<char *>(heap_caps_malloc(buffer_size, MALLOC_CAP_INTERNAL | MALLOC_CAP_8BIT));
   if (buffer == NULL) {
     httpd_resp_send_err(this->_request->request(), HTTPD_500_INTERNAL_SERVER_ERROR, "Unable to allocate memory.");
     return ESP_FAIL;
   }
 
   //send it in one shot or no?
-  if (length < JSON_BUFFER_SIZE)
+  if (length < JSON_INTERNAL_CHUNK_SIZE)
   {
     serializeJson(_root, buffer, buffer_size);
 
@@ -76,7 +79,7 @@ esp_err_t PsychicJsonResponse::send()
   }
 
   //let the buffer go
-  free(buffer);
+  heap_caps_free(buffer);
 
   return err;
 }

--- a/lib/PsychicHttp/src/PsychicResponse.cpp
+++ b/lib/PsychicHttp/src/PsychicResponse.cpp
@@ -141,6 +141,8 @@ esp_err_t PsychicResponse::sendChunk(uint8_t *chunk, size_t chunksize)
 {
   /* Send the buffer contents as HTTP response chunk */
   esp_err_t err = httpd_resp_send_chunk(this->_request->request(), (char *)chunk, chunksize);
+  if (err == ESP_OK)
+    vTaskDelay(1);
   if (err != ESP_OK)
   {
     ESP_LOGE(PH_TAG, "File sending failed (%s)", esp_err_to_name(err));

--- a/lib/framework/ESP32SvelteKit.cpp
+++ b/lib/framework/ESP32SvelteKit.cpp
@@ -13,6 +13,7 @@
  **/
 
 #include <ESP32SvelteKit.h>
+#include <esp_heap_caps.h>
 
 //🌙 added to telemetry
 bool safeModeMB = false; // 🌙 see .h
@@ -111,8 +112,22 @@ void ESP32SvelteKit::begin()
                 response.addHeader("Content-Encoding", "gzip");
                 response.addHeader("Cache-Control", "no-cache"); // 🌙 modified after a user got annoyed ;-)
                 // response.addHeader("Cache-Control", "public, immutable, max-age=31536000"); // 🌙 this is original
-                response.setContent(content, len);
-                return response.send();
+                constexpr size_t chunkSize = 512;
+                uint8_t *chunk = static_cast<uint8_t *>(heap_caps_malloc(chunkSize, MALLOC_CAP_INTERNAL | MALLOC_CAP_8BIT));
+                if (!chunk) return httpd_resp_send_err(request->request(), HTTPD_500_INTERNAL_SERVER_ERROR, "Unable to allocate response buffer.");
+                response.sendHeaders();
+                for (size_t offset = 0; offset < len; offset += chunkSize)
+                {
+                    size_t size = len - offset < chunkSize ? len - offset : chunkSize;
+                    memcpy(chunk, content + offset, size);
+                    esp_err_t err = response.sendChunk(chunk, size);
+                    if (err != ESP_OK) {
+                        heap_caps_free(chunk);
+                        return err;
+                    }
+                }
+                heap_caps_free(chunk);
+                return response.finishChunking();
             };
             PsychicWebHandler *handler = new PsychicWebHandler();
             handler->onRequest(requestHandler);
@@ -153,12 +168,29 @@ void ESP32SvelteKit::begin()
     DefaultHeaders::Instance().addHeader("Access-Control-Allow-Credentials", "true");
 #endif
 
-    ESP_LOGV(SVK_TAG, "Starting MDNS");
-    MDNS.begin(getSystemHostname().c_str()); // 🌙 use unified hostname
-    MDNS.setInstanceName(_appName);
-    MDNS.addService("http", "tcp", 80);
-    MDNS.addService("ws", "tcp", 80);
-    MDNS.addServiceTxt("http", "tcp", "Firmware Version", APP_VERSION);
+    String mdnsHostname = getSystemHostname();
+    mdnsHostname.toLowerCase();
+    if (MDNS.begin(mdnsHostname.c_str()))
+    {
+        MDNS.setInstanceName(mdnsHostname);
+        MDNS.addService("http", "tcp", 80);
+        MDNS.addService("ws", "tcp", 80);
+        MDNS.addServiceTxt("http", "tcp", "Firmware Version", APP_VERSION);
+        WiFi.onEvent(
+            [](WiFiEvent_t, WiFiEventInfo_t) {
+                esp_netif_t *netif = WiFi.STA.netif();
+                if (netif)
+                {
+                    mdns_netif_action(netif, static_cast<mdns_event_actions_t>(MDNS_EVENT_ENABLE_IP4 | MDNS_EVENT_ANNOUNCE_IP4));
+                }
+            },
+            WiFiEvent_t::ARDUINO_EVENT_WIFI_STA_GOT_IP);
+        ESP_LOGI(SVK_TAG, "mDNS started: http://%s.local", mdnsHostname.c_str());
+    }
+    else
+    {
+        ESP_LOGE(SVK_TAG, "mDNS failed to start for %s", mdnsHostname.c_str());
+    }
 
 #ifdef SERIAL_INFO
     Serial.printf("Running Firmware Version: %s\n", APP_VERSION);

--- a/lib/framework/WiFiSettingsService.cpp
+++ b/lib/framework/WiFiSettingsService.cpp
@@ -57,17 +57,18 @@ void WiFiSettingsService::initWiFi()
         WiFiEvent_t::ARDUINO_EVENT_WIFI_STA_DISCONNECTED);
     WiFi.onEvent(std::bind(&WiFiSettingsService::onStationModeStop, this, std::placeholders::_1, std::placeholders::_2),
                  WiFiEvent_t::ARDUINO_EVENT_WIFI_STA_STOP);
-    // 🌙 Reset the reconnection timer when WiFi actually connects so the 5s loop-timer counts
-    // from the moment of successful connection rather than from the last scan attempt.
+    // 🌙 Reset the reconnection timer when DHCP/IP setup completes so the 5s loop-timer counts
+    // from the moment the connection is usable rather than from the last scan attempt.
     // Without this, the timer fires again ~5s after the initial scan (even if already connected)
     // and a brief WiFi.isConnected()==false (e.g. during blocking HTTP calls) triggers a
     // redundant reconnect that forces a disconnect of the active connection.
     WiFi.onEvent(
         [this](WiFiEvent_t, WiFiEventInfo_t) {
             _connecting = false;
+            _connectionStart = 0;
             _lastConnectionAttempt = millis(); // 🌙 restart the 5s timer from now
         },
-        WiFiEvent_t::ARDUINO_EVENT_WIFI_STA_CONNECTED);
+        WiFiEvent_t::ARDUINO_EVENT_WIFI_STA_GOT_IP);
 
     _fsPersistence.readFromFS();
     reconfigureWiFiConnection();
@@ -326,17 +327,18 @@ void WiFiSettingsService::manageSTA()
     if (WiFi.isConnected() || _state.wifiSettings.empty() || _state.staConnectionMode == (u_int8_t)STAConnectionMode::OFFLINE)
     {
         _connecting = false; // 🌙 clear in-flight flag once we know we are connected (or no longer need to connect)
+        _connectionStart = 0;
         return;
     }
     // 🌙 A connection attempt is already in progress — wait for it to succeed or fail.
-    // Safety timeout: if neither CONNECTED nor DISCONNECTED event arrives within 30 s
-    // (e.g. IDF event loop dropped both events), reset _connecting so we can retry.
+    // Safety timeout: if neither GOT_IP nor DISCONNECTED arrives within 30 s, retry.
     if (_connecting)
     {
-        if ((unsigned long)(millis() - _lastConnectionAttempt) < 30000UL)
+        if ((unsigned long)(millis() - _connectionStart) < 30000UL)
             return;
         ESP_LOGW(SVK_TAG, "WiFi connect timeout — no event after 30 s, resetting _connecting");
         _connecting = false;
+        _connectionStart = 0;
     }
     // 🌙 Don't reconnect WiFi while ethernet is active — saves ~50KB heap on ESP32-D0.
     // Only on non-PSRAM boards; PSRAM boards (S3/P4) have enough heap for both stacks.
@@ -478,6 +480,7 @@ void WiFiSettingsService::configureNetwork(wifi_settings_t &network)
 
     // attempt to connect to the network
     _connecting = true; // 🌙 guard against re-entrant manageSTA calls during connection
+    _connectionStart = millis();
     WiFi.begin(network.ssid.c_str(), network.password.c_str(), network.channel, network.bssid);
     // WiFi.begin(network.ssid.c_str(), network.password.c_str());
 
@@ -523,6 +526,7 @@ void WiFiSettingsService::updateRSSI()
 void WiFiSettingsService::onStationModeDisconnected(WiFiEvent_t event, WiFiEventInfo_t info)
 {
     _connecting = false;                      // 🌙 connection attempt ended (failed or dropped)
+    _connectionStart = 0;
     _lastConnectionAttempt = millis();        // 🌙 retry after WIFI_RECONNECTION_DELAY — avoids scanning while WiFi stack is still mid-connection
 }
 

--- a/lib/framework/WiFiSettingsService.cpp
+++ b/lib/framework/WiFiSettingsService.cpp
@@ -277,6 +277,17 @@ bool sendAnalytics() {
 void WiFiSettingsService::loop()
 {
     unsigned long currentMillis = millis();
+    static unsigned long lastMdnsAnnounce = 0;
+
+    if (WiFi.isConnected() && (unsigned long)(currentMillis - lastMdnsAnnounce) >= 60000UL)
+    {
+        lastMdnsAnnounce = currentMillis;
+        esp_netif_t *netif = WiFi.STA.netif();
+        if (netif)
+        {
+            mdns_netif_action(netif, static_cast<mdns_event_actions_t>(MDNS_EVENT_ENABLE_IP4 | MDNS_EVENT_ANNOUNCE_IP4));
+        }
+    }
 
     // Handle delayed reconnection
     if (_delayedReconnectPending && currentMillis >= _delayedReconnectTime)

--- a/lib/framework/WiFiSettingsService.h
+++ b/lib/framework/WiFiSettingsService.h
@@ -244,6 +244,7 @@ private:
     FSPersistence<WiFiSettings> _fsPersistence;
     EventSocket *_socket;
     unsigned long _lastConnectionAttempt;
+    unsigned long _connectionStart = 0; // 🌙 start of the current WiFi.begin() attempt
     unsigned long _lastRssiUpdate;
     unsigned long _delayedReconnectTime;
     bool _delayedReconnectPending;

--- a/platformio.ini
+++ b/platformio.ini
@@ -56,8 +56,8 @@ build_flags =
 	${features.build_flags}
     -D BUILD_TARGET=\"$PIOENV\"
     -D APP_NAME=\"MoonLight\" ; 🌙 Must only contain characters from [a-zA-Z0-9-_] as this is converted into a filename
-    -D APP_VERSION=\"1.0.0\" ; semver compatible version string
-    -D APP_DATE=\"20260505\" ; 🌙
+    -D APP_VERSION=\"1.0.0-whitevest.2\" ; semver compatible version string
+    -D APP_DATE=\"20260816\" ; 🌙
 
     -D PLATFORM_VERSION=\"pioarduino-55.03.37\" ; 🌙 make sure it matches with above plaftform
 

--- a/platformio.ini
+++ b/platformio.ini
@@ -56,8 +56,8 @@ build_flags =
 	${features.build_flags}
     -D BUILD_TARGET=\"$PIOENV\"
     -D APP_NAME=\"MoonLight\" ; 🌙 Must only contain characters from [a-zA-Z0-9-_] as this is converted into a filename
-    -D APP_VERSION=\"1.0.0-whitevest.2\" ; semver compatible version string
-    -D APP_DATE=\"20260816\" ; 🌙
+    -D APP_VERSION=\"1.0.0\" ; semver compatible version string
+    -D APP_DATE=\"20260505\" ; 🌙
 
     -D PLATFORM_VERSION=\"pioarduino-55.03.37\" ; 🌙 make sure it matches with above plaftform
 

--- a/scripts/merge_bin.py
+++ b/scripts/merge_bin.py
@@ -10,7 +10,7 @@ BOARD_CONFIG = env.BoardConfig()
 def readFlag(flag):
     buildFlags = env.ParseFlags(env["BUILD_FLAGS"])
     # print(buildFlags.get("CPPDEFINES"))
-    for define in buildFlags.get("CPPDEFINES"):
+    for define in reversed(buildFlags.get("CPPDEFINES")):
         if (define == flag or (isinstance(define, list) and define[0] == flag)):
             # print("Found "+flag+" = "+define[1])
             # strip quotes ("") from define[1]

--- a/scripts/rename_fw.py
+++ b/scripts/rename_fw.py
@@ -27,7 +27,7 @@ OUTPUT_DIR = "build{}release{}".format(os.path.sep, os.path.sep)
 def readFlag(flag):
     buildFlags = env.ParseFlags(env["BUILD_FLAGS"])
     # print(buildFlags.get("CPPDEFINES"))
-    for define in buildFlags.get("CPPDEFINES"):
+    for define in reversed(buildFlags.get("CPPDEFINES")):
         if (define == flag or (isinstance(define, list) and define[0] == flag)):
             # print("Found "+flag+" = "+define[1])
             # strip quotes ("") from define[1]

--- a/src/MoonBase/Nodes.h
+++ b/src/MoonBase/Nodes.h
@@ -271,6 +271,7 @@ extern SharedData sharedData;
   #include "MoonLight/Nodes/Effects/E_WLED.h"
   #include "MoonLight/Nodes/Effects/E__Sandbox.h"
   #include "MoonLight/Nodes/Layouts/L_MoonLight.h"
+  #include "MoonLight/Nodes/Layouts/L_WhiteVest95.h"
   #include "MoonLight/Nodes/Layouts/L_SE16.h"
   #include "MoonLight/Nodes/Layouts/L__Sandbox.h"
   #include "MoonLight/Nodes/Modifiers/M_MoonLight.h"

--- a/src/MoonLight/Modules/ModuleDrivers.h
+++ b/src/MoonLight/Modules/ModuleDrivers.h
@@ -120,6 +120,7 @@ class ModuleDrivers : public NodeManager {
     addNodeValue<SingleRowLayout>(control);
     addNodeValue<SingleColumnLayout>(control);
     addNodeValue<TubesLayout>(control);
+    addNodeValue<WhiteVest95Layout>(control);
 
     // Drivers, Most used first
     addNodeValue<ParallelLEDDriver>(control);
@@ -180,6 +181,7 @@ class ModuleDrivers : public NodeManager {
     if (!node) node = checkAndAlloc<SingleRowLayout>(name);
     if (!node) node = checkAndAlloc<SingleColumnLayout>(name);
     if (!node) node = checkAndAlloc<TubesLayout>(name);
+    if (!node) node = checkAndAlloc<WhiteVest95Layout>(name);
 
     // Drivers most used first
     if (!node) node = checkAndAlloc<ParallelLEDDriver>(name);
@@ -208,6 +210,12 @@ class ModuleDrivers : public NodeManager {
           if (!node && strcmp(boardPreset, BoardName::LightCrafter16) == 0) node = checkAndAlloc<LightCrafter16Layout>(name);
         },
         _moduleName);
+
+    // Migration: the White Vest layout moved from Live Script to native C++.
+    if (!node && equalAZaz09(name, "/L_WhiteVest95.sc")) {
+      strlcpy(name, getNameAndTags<WhiteVest95Layout>().c_str(), 32);
+      node = allocMBObject<WhiteVest95Layout>();
+    }
 
   #if FT_LIVESCRIPT
     if (!node && !safeModeMB) {

--- a/src/MoonLight/Modules/ModuleLightsControl.h
+++ b/src/MoonLight/Modules/ModuleLightsControl.h
@@ -255,7 +255,11 @@ class ModuleLightsControl : public Module {
             } else if (usage == pin_Button_Push_LightsOn) {
               if (GPIO_IS_VALID_GPIO(gpio)) {
                 pinPushButtonLightsOn = gpio;
+#if CONFIG_IDF_TARGET_ESP32
+                pinMode(pinPushButtonLightsOn, gpio >= 34 && gpio <= 39 ? INPUT : INPUT_PULLUP);
+#else
                 pinMode(pinPushButtonLightsOn, INPUT_PULLUP);
+#endif
                 EXT_LOGD(ML_TAG, "pinPushButtonLightsOn found %d", pinPushButtonLightsOn);
               } else
                 EXT_LOGE(MB_TAG, "gpio %d not valid", pinPushButtonLightsOn);

--- a/src/MoonLight/Nodes/Drivers/D_FastLEDAudio.h
+++ b/src/MoonLight/Nodes/Drivers/D_FastLEDAudio.h
@@ -17,6 +17,7 @@
   #include "fl/audio/audio_processor.h"
   #include "fl/audio/detector/equalizer.h"
   #include "fl/audio/input.h"
+  #include <driver/i2s_pdm.h>
 // #include "fl/time_alpha.h"
 
 // https://github.com/FastLED/FastLED/blob/master/src/fl/audio/README.md
@@ -28,6 +29,9 @@ class FastLEDAudioDriver : public Node {
   fl::audio::ConfigPdm* pdmConfig = nullptr;
   fl::audio::Config* config = nullptr;
   fl::shared_ptr<fl::audio::IInput> audioInput;
+  i2s_chan_handle_t pdmRxHandle = nullptr;
+  bool boundedPdmActive = false;
+  uint64_t pdmSamples = 0;
 
  public:
   static const char* name() { return "FastLED Audio"; }
@@ -42,8 +46,11 @@ class FastLEDAudioDriver : public Node {
   bool noiseFloorTracking = false;
   uint8_t channel = (uint8_t)fl::audio::AudioChannel::Left;
   uint8_t gain = 128;
-  bool drainBuffer = false;  // if false 60 fps. otherwise 40 fps
+  bool drainBuffer = true;  // process the complete PDM buffer so EQ and beat detection receive enough samples
   Char<32> status = "No pins";
+  uint32_t samplesCaptured = 0;
+  uint8_t audioLevel = 0;
+  uint32_t lastTelemetryUpdate = 0;
 
   void setup() override {
     addControl(signalConditioning, "signalConditioning", "checkbox");
@@ -54,8 +61,15 @@ class FastLEDAudioDriver : public Node {
     addControlValue("Left");
     addControlValue("Right");
     addControlValue("Both");
-    addControl(drainBuffer, "drainBuffer", "checkbox");
+    JsonObject drainBufferControl = addControl(drainBuffer, "drainBuffer", "checkbox");
+    // The legacy false default starves the 44.1 kHz processor at the driver loop rate.
+    if (!drainBuffer) {
+      drainBuffer = true;
+      drainBufferControl["value"] = true;
+    }
     addControl(status, "status", "text", 0, 32, true);
+    addControl(samplesCaptured, "samples", "number", 0, UINT8_MAX, true);
+    addControl(audioLevel, "level", "number", 0, UINT8_MAX, true);
 
     ioUpdateHandler = moduleIO->addUpdateHandler([this](const String& originId) { readPins(); });
     readPins();  // Node added at runtime so initial IO update not received so run explicitly
@@ -183,7 +197,8 @@ class FastLEDAudioDriver : public Node {
   }
 
   void loop() override {
-    if (!audioInput) return;
+    if (!drainBuffer) updateControl("drainBuffer", true);
+    if (!audioInput && !boundedPdmActive) return;
 
     sharedData.fl_beat = false;
     sharedData.fl_kick = false;
@@ -197,14 +212,28 @@ class FastLEDAudioDriver : public Node {
     // Calling audioInput->read() only once per iteration drains a single sample while leaving the remaining buffered samples unprocessed.
     // With 44.1 kHz input and typical loop cadence (~20 ms), roughly 800+ samples accumulate and are discarded each frame, causing severe data loss and degraded EQ/beat/BPM detection.
 
-    if (drainBuffer) {
+    if (boundedPdmActive) {
+      int16_t samples[256];
+      while (true) {
+        size_t bytesRead = 0;
+        esp_err_t err = i2s_channel_read(pdmRxHandle, samples, sizeof(samples), &bytesRead, 0);
+        if (err != ESP_OK || bytesRead == 0) break;
+        size_t count = bytesRead / sizeof(samples[0]);
+        uint32_t timestamp = static_cast<uint32_t>(pdmSamples * 1000ULL / 44100ULL);
+        pdmSamples += count;
+        samplesCaptured += count;
+        audioProcessor.update(fl::audio::Sample(fl::span<const fl::i16>(samples, count), timestamp));
+      }
+    } else if (drainBuffer) {
       while (fl::audio::Sample sample = audioInput->read()) {
+        samplesCaptured += sample.size();
         audioProcessor.update(sample);
       }
 
     } else {
       fl::audio::Sample sample = audioInput->read();
       if (sample.isValid()) {
+        samplesCaptured += sample.size();
         audioProcessor.update(sample);
       }
     }
@@ -215,6 +244,7 @@ class FastLEDAudioDriver : public Node {
     // Volume system overhaul — now 0.0–1.0 normalized: https://github.com/FastLED/FastLED/issues/2193#issuecomment-4192711473
     // const float norm = (audioProcessor.getEqVolumeNormFactor() > 0.000001f) ? audioProcessor.getEqVolumeNormFactor() : 1.0f;
     sharedData.volume = audioProcessor.getEqVolume() * 255.0;// normalised volume (   * 255 * 2560.0f; // WLED correction!)
+    audioLevel = sharedData.volume < 0 ? 0 : sharedData.volume > 255 ? 255 : static_cast<uint8_t>(sharedData.volume);
     sharedData.volumeRaw = (int16_t)sharedData.volume;
     // sharedData.volumeRaw = audioProcessor.getEqVolumeDb() * 255;
     sharedData.majorPeak = audioProcessor.getEqDominantFreqHz();
@@ -235,6 +265,12 @@ class FastLEDAudioDriver : public Node {
     sharedData.fl_beat = sharedData.fl_beatConfidence > 0.5f;  // audioProcessor.isBeat(); // not implemented yet ...
 
     sharedData.fl_bpm = audioProcessor.getBPM();
+
+    if (millis() - lastTelemetryUpdate >= 500) {
+      lastTelemetryUpdate = millis();
+      updateControl("samples", samplesCaptured);
+      updateControl("level", audioLevel);
+    }
   }
 
   void startService() {
@@ -244,8 +280,12 @@ class FastLEDAudioDriver : public Node {
       config = new fl::audio::Config(*i2sConfig);
     } else {
       // PDM microphone (2 pins: SD=data, WS=clock) — e.g. QuinLED Dig-Next-2
-      pdmConfig = new fl::audio::ConfigPdm(pinI2SSD, pinI2SWS, 0);
-      config = new fl::audio::Config(*pdmConfig);
+      if (startBoundedPdm()) {
+        updateControl("status", "PDM active");
+      } else {
+        updateControl("status", "Failed to initialize PDM audio");
+      }
+      return;
     }
 
     fl::string errorMsg;
@@ -266,6 +306,15 @@ class FastLEDAudioDriver : public Node {
   }
 
   void stopService() {
+    if (boundedPdmActive) {
+      i2s_channel_disable(pdmRxHandle);
+      i2s_del_channel(pdmRxHandle);
+      pdmRxHandle = nullptr;
+      boundedPdmActive = false;
+      pdmSamples = 0;
+      samplesCaptured = 0;
+      updateControl("status", "Stopped");
+    }
     if (audioInput) {
       audioInput->stop();
       audioInput.reset();
@@ -287,6 +336,49 @@ class FastLEDAudioDriver : public Node {
       delete pdmConfig;
       pdmConfig = nullptr;
     }
+  }
+
+  bool startBoundedPdm() {
+    i2s_chan_config_t channel = I2S_CHANNEL_DEFAULT_CONFIG(I2S_NUM_0, I2S_ROLE_MASTER);
+    channel.dma_desc_num = 4;
+    channel.dma_frame_num = 256;
+
+    esp_err_t err = i2s_new_channel(&channel, nullptr, &pdmRxHandle);
+    if (err != ESP_OK) {
+      EXT_LOGE(ML_TAG, "Failed to create PDM I2S channel: %s", esp_err_to_name(err));
+      return false;
+    }
+
+    i2s_pdm_rx_config_t pdm = {
+      .clk_cfg = I2S_PDM_RX_CLK_DEFAULT_CONFIG(44100),
+      .slot_cfg = I2S_PDM_RX_SLOT_DEFAULT_CONFIG(I2S_DATA_BIT_WIDTH_16BIT, I2S_SLOT_MODE_MONO),
+      .gpio_cfg = {
+        .clk = static_cast<gpio_num_t>(pinI2SWS),
+        .din = static_cast<gpio_num_t>(pinI2SSD),
+        .invert_flags = {
+          .clk_inv = false,
+        },
+      },
+    };
+    err = i2s_channel_init_pdm_rx_mode(pdmRxHandle, &pdm);
+    if (err != ESP_OK) {
+      EXT_LOGE(ML_TAG, "Failed to initialize PDM RX mode: %s", esp_err_to_name(err));
+      i2s_del_channel(pdmRxHandle);
+      pdmRxHandle = nullptr;
+      return false;
+    }
+
+    err = i2s_channel_enable(pdmRxHandle);
+    if (err != ESP_OK) {
+      EXT_LOGE(ML_TAG, "Failed to enable PDM channel: %s", esp_err_to_name(err));
+      i2s_del_channel(pdmRxHandle);
+      pdmRxHandle = nullptr;
+      return false;
+    }
+
+    pdmSamples = 0;
+    boundedPdmActive = true;
+    return true;
   }
 
   ~FastLEDAudioDriver() override {

--- a/src/MoonLight/Nodes/Drivers/D_FastLEDDriver.h
+++ b/src/MoonLight/Nodes/Drivers/D_FastLEDDriver.h
@@ -44,6 +44,8 @@ class FastLEDDriver : public DriverNode {
   #endif
     addControl(engine, "engine", "text", 0, 32, true);  // the resolved engine based on affinity
 
+    reserveRmtForPdm();
+
     addControl(temperature, "temperature", "select");
     addControlValue("Uncorrected");
     addControlValue("Candle");
@@ -61,6 +63,7 @@ class FastLEDDriver : public DriverNode {
     addControl(status, "status", "text", 0, 32, true);
 
     ioUpdateHandler = moduleIO->addUpdateHandler([this](const String& originId) {
+      reserveRmtForPdm();
       uint8_t nrOfPins = MIN(layerP.nrOfLedPins, layerP.nrOfAssignedPins);
 
       EXT_LOGD(ML_TAG, "recreate channels and configs %s %d", originId.c_str(), nrOfPins);
@@ -91,6 +94,23 @@ class FastLEDDriver : public DriverNode {
 
   fl::EOrder rgbOrder = GRB;
   fl::ChannelOptions options = fl::ChannelOptions();
+
+  void reserveRmtForPdm() {
+    bool hasPdmData = false;
+    bool hasPdmClock = false;
+    moduleIO->read([&](ModuleState& state) {
+      for (JsonObject pinObject : state.data["pins"].as<JsonArray>()) {
+        uint8_t usage = pinObject["usage"];
+        hasPdmData = hasPdmData || usage == pin_I2S_SD;
+        hasPdmClock = hasPdmClock || usage == pin_I2S_WS;
+      }
+    }, "FastLEDDriver");
+    if (hasPdmData && hasPdmClock) {
+      affinity = 1;
+      updateControl("affinity", affinity);
+      options.mAffinity = "RMT";
+    }
+  }
 
   void onUpdate(const JsonObject& control) override {
     DriverNode::onUpdate(control);  // !!

--- a/src/MoonLight/Nodes/Layouts/L_WhiteVest95.h
+++ b/src/MoonLight/Nodes/Layouts/L_WhiteVest95.h
@@ -1,0 +1,125 @@
+/**
+    @title     MoonLight
+    @file      L_WhiteVest95.h
+    @repo      https://github.com/novotnyllc/MoonLight
+    @Copyright © 2026 GitHub MoonLight Commit Authors
+    @license   GNU GENERAL PUBLIC LICENSE Version 3, 29 June 2007
+**/
+
+#pragma once
+
+#if FT_MOONLIGHT
+
+class WhiteVest95Layout : public Node {
+ public:
+  static const char* name() { return "White Vest 95"; }
+  static uint8_t dim() { return _3D; }
+  static const char* tags() { return "🚥"; }
+  static const char* category() { return "Layout"; }
+
+  Coord3D vestCoord(uint32_t x, uint32_t y, uint32_t z) const {
+    return Coord3D((x * 5U + 127U) / 255U, (y * 5U + 127U) / 255U, (z * 19U + 127U) / 255U);
+  }
+
+  bool hasOnLayout() const override { return true; }
+  void onLayout() override {
+    addLight(vestCoord(44, 31, 40));
+    addLight(vestCoord(44, 31, 65));
+    addLight(vestCoord(44, 31, 90));
+    addLight(vestCoord(44, 31, 127));
+    addLight(vestCoord(44, 31, 164));
+    addLight(vestCoord(44, 31, 213));
+    addLight(vestCoord(44, 31, 250));
+    addLight(vestCoord(15, 68, 248));
+    addLight(vestCoord(15, 68, 212));
+    addLight(vestCoord(15, 68, 194));
+    addLight(vestCoord(15, 68, 147));
+    addLight(vestCoord(15, 68, 118));
+    addLight(vestCoord(15, 68, 82));
+    addLight(vestCoord(15, 68, 102));
+    addLight(vestCoord(15, 68, 15));
+    addLight(vestCoord(1, 113, 30));
+    addLight(vestCoord(1, 113, 56));
+    addLight(vestCoord(1, 113, 81));
+    addLight(vestCoord(1, 113, 116));
+    addLight(vestCoord(1, 113, 151));
+    addLight(vestCoord(1, 113, 191));
+    addLight(vestCoord(1, 113, 208));
+    addLight(vestCoord(4, 160, 174));
+    addLight(vestCoord(4, 160, 146));
+    addLight(vestCoord(4, 160, 110));
+    addLight(vestCoord(4, 160, 73));
+    addLight(vestCoord(4, 160, 52));
+    addLight(vestCoord(4, 160, 28));
+    addLight(vestCoord(4, 160, 20));
+    addLight(vestCoord(25, 203, 53));
+    addLight(vestCoord(25, 203, 82));
+    addLight(vestCoord(25, 203, 103));
+    addLight(vestCoord(25, 203, 139));
+    addLight(vestCoord(25, 203, 182));
+    addLight(vestCoord(25, 203, 224));
+    addLight(vestCoord(25, 203, 253));
+    addLight(vestCoord(60, 235, 248));
+    addLight(vestCoord(60, 235, 210));
+    addLight(vestCoord(60, 235, 165));
+    addLight(vestCoord(60, 235, 124));
+    addLight(vestCoord(60, 235, 87));
+    addLight(vestCoord(60, 235, 64));
+    addLight(vestCoord(60, 235, 37));
+    addLight(vestCoord(104, 253, 48));
+    addLight(vestCoord(104, 253, 73));
+    addLight(vestCoord(104, 253, 104));
+    addLight(vestCoord(104, 253, 143));
+    addLight(vestCoord(104, 253, 189));
+    addLight(vestCoord(104, 253, 233));
+    addLight(vestCoord(104, 253, 245));
+    addLight(vestCoord(151, 253, 251));
+    addLight(vestCoord(151, 253, 214));
+    addLight(vestCoord(151, 253, 168));
+    addLight(vestCoord(151, 253, 124));
+    addLight(vestCoord(151, 253, 81));
+    addLight(vestCoord(151, 253, 54));
+    addLight(vestCoord(151, 253, 27));
+    addLight(vestCoord(195, 235, 40));
+    addLight(vestCoord(195, 235, 69));
+    addLight(vestCoord(195, 235, 106));
+    addLight(vestCoord(195, 235, 148));
+    addLight(vestCoord(195, 235, 191));
+    addLight(vestCoord(195, 235, 240));
+    addLight(vestCoord(195, 235, 234));
+    addLight(vestCoord(230, 203, 253));
+    addLight(vestCoord(230, 203, 223));
+    addLight(vestCoord(230, 203, 181));
+    addLight(vestCoord(230, 203, 163));
+    addLight(vestCoord(230, 203, 121));
+    addLight(vestCoord(230, 203, 81));
+    addLight(vestCoord(230, 203, 55));
+    addLight(vestCoord(230, 203, 20));
+    addLight(vestCoord(251, 160, 64));
+    addLight(vestCoord(251, 160, 95));
+    addLight(vestCoord(251, 160, 138));
+    addLight(vestCoord(251, 160, 156));
+    addLight(vestCoord(254, 113, 116));
+    addLight(vestCoord(254, 113, 77));
+    addLight(vestCoord(254, 113, 40));
+    addLight(vestCoord(254, 113, 6));
+    addLight(vestCoord(240, 68, 65));
+    addLight(vestCoord(240, 68, 90));
+    addLight(vestCoord(240, 68, 105));
+    addLight(vestCoord(240, 68, 135));
+    addLight(vestCoord(240, 68, 169));
+    addLight(vestCoord(240, 68, 184));
+    addLight(vestCoord(240, 68, 195));
+    addLight(vestCoord(240, 68, 248));
+    addLight(vestCoord(211, 31, 240));
+    addLight(vestCoord(211, 31, 209));
+    addLight(vestCoord(211, 31, 164));
+    addLight(vestCoord(211, 31, 118));
+    addLight(vestCoord(211, 31, 85));
+    addLight(vestCoord(211, 31, 65));
+    addLight(vestCoord(211, 31, 22));
+    nextPin();
+  }
+};
+
+#endif  // FT_MOONLIGHT


### PR DESCRIPTION
## Summary

Dig-Next-2 wearable controllers can now serve the full MoonLight UI, remain discoverable by their configured `.local` hostname, and use the built-in PDM microphone without competing with LED output for I2S. The runtime remains garment-independent: the previously merged White Vest layout stays selected on this device, while future coat geometry can use the same firmware once its canonical map exists.

The implementation moves HTTP response buffers into bounded internal-RAM chunks, refreshes mDNS across DHCP and routed TTL boundaries, reserves RMT for LEDs when PDM pins are present, uses a bounded current-API PDM capture ring, and avoids unsupported internal pull-ups on classic ESP32 GPIO34-39.

## Validation

- `pio run -e esp32-d0-pico2` completed successfully.
- App-only flash completed with esptool data-hash verification. The device reports `1.0.1-dignext2.2` and sketch size `2754064`.
- `/` returned HTTP 200 in 0.31 s; `/rest/drivers` returned its complete 2,330-byte body in 0.32 s.
- `white-vest-next.local` resolved and returned 3/3 ping replies after 185 seconds uptime, beyond the original 120-second mDNS TTL.
- The live layout reports 95 RGB pixels, a `6x6x20` extent, and 95 unique occupied cells in the 720-cell virtual volume.
- LED output is GPIO2 through RMT. PDM status is active; captured samples advanced from 78,214,400 to 80,602,880 and the live level changed from 196 to 120.
- The staged diff passed `git diff --cached --check` and a focused added-line secret scan.

## Remaining physical gates

- Connect the known 12 V, 95-pixel vest string and validate a low-brightness solid color before mapped effects.
- Confirm a sound-reactive effect visibly follows microphone input.
- Capture the private full-flash restoration image only after those checks pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added native support for the 95-pixel White Vest layout, including automatic migration from legacy layout references.
  - Added PDM microphone support and audio-reactive lighting with improved telemetry.
  - Improved compatibility between audio input and LED hardware resources.

- **Bug Fixes**
  - Improved Wi-Fi reconnection timing and mDNS availability after obtaining an IP address.
  - Increased reliability when serving larger web responses.
  - Improved network responsiveness during data transfers.

- **Release**
  - Updated the firmware identity to version 1.0.1-dignext2.2.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->